### PR TITLE
Define the correct icon_path configuration value in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Following Semantic Versioning 2.
 
 ## next version:
+- DOC: Define the correct icon_path configuration value in README
 
 ## Version 0.3.0 (MINOR)
 - Update omniauth-idcat_mobil: Send the client_id and the client_secret during the AuthToken retrieval.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Check how to configure the strategy in [Decidim's related documentation](https:/
   omniauth:
     idcat_mobil:
       enabled: true
-      icon_path: decidim/idcat_mobil/idcat_mobil-icon.svg
+      icon_path: media/images/idcat_mobil-icon.svg
 ```
 
 Remember to set `IDCAT_MOBIL_CLIENT_ID`, `IDCAT_MOBIL_CLIENT_SECRET` and `IDCAT_MOBIL_SITE_URL` environment variables.


### PR DESCRIPTION
#### :tophat: What? Why?
In the README we were still showing a configuration from before the use of `webpack` in the asset pipeline.
This PR fixes this configuration example.